### PR TITLE
- Feature/api gateway alias

### DIFF
--- a/es5/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayResource.js
+++ b/es5/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayResource.js
@@ -97,9 +97,9 @@ var ConanAwsApiGatewayResource = (function (_ConanComponent) {
 			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsFindResourceMethodStepJs2["default"], this);
 			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsCreateResourceMethodStepJs2["default"], this);
 			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsPutIntegrationStepJs2["default"], this);
-			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsPutIntegrationResponseStepJs2["default"], this);
 			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsFindMethodResponseStepJs2["default"], this);
 			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsPutMethodResponseStepJs2["default"], this);
+			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsPutIntegrationResponseStepJs2["default"], this);
 			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsGetAccountIdStepJs2["default"], this);
 			this.conan.steps.before(_stepsFindApiStageByNameStepJs2["default"], _stepsAddPermissionStepJs2["default"], this);
 		}

--- a/es5/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayResource.js
+++ b/es5/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayResource.js
@@ -80,9 +80,9 @@ var ConanAwsApiGatewayResource = (function (_ConanComponent) {
 		value: function initialize(conan, path, method) {
 			this.conan = conan;
 
-			this.parameters("path", "method", "lambda", "statusCodes", "responseHeaders");
+			this.parameters("path", "method", "statusCodes", "responseHeaders");
 
-			this.multipleValueParameters("headers", "queryStrings");
+			this.multipleValueParameters("lambda", "headers", "queryStrings");
 
 			this.path(path);
 			this.method(method);

--- a/es5/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayStage.js
+++ b/es5/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayStage.js
@@ -87,6 +87,11 @@ var ConanAwsApiGatewayStage = (function (_ConanComponent) {
 		value: function _delete(path) {
 			return new _conanAwsApiGatewayResourceJs2["default"](this.conan, path, "DELETE");
 		}
+	}, {
+		key: "options",
+		value: function options(path) {
+			return new _conanAwsApiGatewayResourceJs2["default"](this.conan, path, "OPTIONS");
+		}
 	}]);
 
 	return ConanAwsApiGatewayStage;

--- a/es5/lib/plugins/aws-api-gateway/spec/components/conanAwsGatewayApiResource.spec.js
+++ b/es5/lib/plugins/aws-api-gateway/spec/components/conanAwsGatewayApiResource.spec.js
@@ -49,7 +49,7 @@ describe("ConanAwsApiGatewayResource(conan)", function () {
 	});
 
 	describe("(parameters)", function () {
-		["path", "method", "lambda", "statusCodes", "responseHeaders"].forEach(function (parameterName) {
+		["path", "method", "statusCodes", "responseHeaders"].forEach(function (parameterName) {
 			var parameterNamePascalCase = (0, _jargon2["default"])(parameterName).pascal.toString();
 
 			describe("." + parameterName + "(new" + parameterNamePascalCase + ")", function () {
@@ -64,7 +64,7 @@ describe("ConanAwsApiGatewayResource(conan)", function () {
 	});
 
 	describe("(multiple-value parameters)", function () {
-		["headers", "queryStrings"].forEach(function (parameterName) {
+		["headers", "lambda", "queryStrings"].forEach(function (parameterName) {
 			var parameterNamePascalCase = (0, _jargon2["default"])(parameterName).pascal.toString();
 
 			describe("." + parameterName + "(new" + parameterNamePascalCase + ")", function () {

--- a/es5/lib/plugins/aws-api-gateway/spec/components/conanAwsGatewayApiStage.spec.js
+++ b/es5/lib/plugins/aws-api-gateway/spec/components/conanAwsGatewayApiStage.spec.js
@@ -100,7 +100,7 @@ describe("ConanAwsApiGatewayStage(conan, name)", function () {
 		});
 	});
 
-	["GET", "POST", "PUT", "DELETE"].forEach(function (resourceMethod) {
+	["GET", "POST", "PUT", "DELETE", "OPTIONS"].forEach(function (resourceMethod) {
 		var methodFunctionName = resourceMethod.toLowerCase();
 		describe("stage." + methodFunctionName + "(path)", function () {
 			var newResource = undefined;

--- a/es5/lib/plugins/aws-api-gateway/spec/steps/putIntegrationStep.spec.js
+++ b/es5/lib/plugins/aws-api-gateway/spec/steps/putIntegrationStep.spec.js
@@ -88,6 +88,11 @@ describe("putIntegrationStep", function () {
 				value: function queryStrings() {
 					return [];
 				}
+			}, {
+				key: "lambda",
+				value: function lambda() {
+					return [];
+				}
 			}]);
 
 			return MockConanAwsParameters;
@@ -150,6 +155,11 @@ describe("putIntegrationStep", function () {
 						value: function queryStrings() {
 							return [];
 						}
+					}, {
+						key: "lambda",
+						value: function lambda() {
+							return [];
+						}
 					}]);
 
 					return MockConanAwsParameters;
@@ -192,6 +202,11 @@ describe("putIntegrationStep", function () {
 						value: function queryStrings() {
 							return ["pageSize"];
 						}
+					}, {
+						key: "lambda",
+						value: function lambda() {
+							return [];
+						}
 					}]);
 
 					return MockConanAwsParameters;
@@ -232,6 +247,11 @@ describe("putIntegrationStep", function () {
 					}, {
 						key: "queryStrings",
 						value: function queryStrings() {
+							return [];
+						}
+					}, {
+						key: "lambda",
+						value: function lambda() {
 							return [];
 						}
 					}]);
@@ -289,6 +309,87 @@ describe("putIntegrationStep", function () {
 		it("should return with no error", function (done) {
 			(0, _stepsPutIntegrationStepJs2["default"])(conan, context, function (error) {
 				should.not.exist(error);
+				done();
+			});
+		});
+	});
+
+	describe("(resource method created with alias)", function () {
+		var responseData = undefined;
+
+		beforeEach(function () {
+			parameters = new ((function () {
+				function MockConanAwsParameters() {
+					_classCallCheck(this, MockConanAwsParameters);
+				}
+
+				_createClass(MockConanAwsParameters, [{
+					key: "method",
+					value: function method() {
+						return "GET";
+					}
+				}, {
+					key: "path",
+					value: function path() {
+						return "/account/items";
+					}
+				}, {
+					key: "headers",
+					value: function headers() {
+						return [];
+					}
+				}, {
+					key: "queryStrings",
+					value: function queryStrings() {
+						return [];
+					}
+				}, {
+					key: "lambda",
+					value: function lambda() {
+						return ["testFunction", "development"];
+					}
+				}]);
+
+				return MockConanAwsParameters;
+			})())();
+			context = {
+				parameters: parameters,
+				results: {
+					restApiId: restApiId,
+					apiResourceId: apiResourceId,
+					lambdaArn: lambdaArn
+				},
+				libraries: {
+					AWS: {
+						APIGateway: APIGateway
+					}
+				}
+			};
+			responseData = {};
+			uri = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/" + lambdaArn + ":development/invocations";
+			putIntegrationSpy = _sinon2["default"].spy(function (awsParameters, callback) {
+				callback(null, responseData);
+			});
+		});
+
+		it("should return with no error", function (done) {
+			(0, _stepsPutIntegrationStepJs2["default"])(conan, context, function (error) {
+				should.not.exist(error);
+				done();
+			});
+		});
+
+		it("should use the alias on the uri", function (done) {
+			(0, _stepsPutIntegrationStepJs2["default"])(conan, context, function () {
+				putIntegrationSpy.firstCall.args[0].should.eql({
+					resourceId: apiResourceId,
+					httpMethod: parameters.method(),
+					type: "AWS",
+					integrationHttpMethod: "POST",
+					uri: uri,
+					requestTemplates: requestTemplates,
+					restApiId: restApiId
+				});
 				done();
 			});
 		});

--- a/es5/lib/plugins/aws-api-gateway/steps/addPermissionStep.js
+++ b/es5/lib/plugins/aws-api-gateway/steps/addPermissionStep.js
@@ -21,7 +21,7 @@ function addPermissionStep(conan, context, stepDone) {
 	});
 	if (typeof context.parameters.lambda === "function" && typeof context.parameters.method === "function" && typeof context.parameters.path === "function" && accountId && restApiId) {
 		(function () {
-			var lambdaName = context.parameters.lambda();
+			var lambdaName = context.parameters.lambda()[0];
 			var method = context.parameters.method();
 			var path = context.parameters.path();
 			if (lambdaName) {
@@ -45,13 +45,17 @@ function addPermissionStep(conan, context, stepDone) {
 						}
 					}
 					if (!statement) {
-						lambda.addPermission({
+						var apiParameters = {
 							"FunctionName": lambdaName,
 							"SourceArn": sourceArn,
 							"Action": "lambda:InvokeFunction",
 							"Principal": "apigateway.amazonaws.com",
 							"StatementId": _hacher2["default"].getUUID()
-						}, function (error) {
+						};
+						if (context.parameters.lambda().length > 1) {
+							apiParameters.Qualifier = context.parameters.lambda()[1];
+						}
+						lambda.addPermission(apiParameters, function (error) {
 							if (error && error.statusCode === 409) {
 								stepDone(null);
 							} else if (error) {

--- a/es5/lib/plugins/aws-api-gateway/steps/putIntegrationStep.js
+++ b/es5/lib/plugins/aws-api-gateway/steps/putIntegrationStep.js
@@ -52,8 +52,12 @@ function putIntegrationStep(conan, context, done) {
 		};
 
 		if (lambdaArn) {
+			var aliasSuffix = "";
+			if (context.parameters.lambda().length > 1) {
+				aliasSuffix = ":" + context.parameters.lambda()[1];
+			}
 			apiParameters.type = "AWS";
-			apiParameters.uri = "arn:aws:apigateway:" + conan.config.region + ":lambda:path/2015-03-31/functions/" + lambdaArn + "/invocations";
+			apiParameters.uri = "arn:aws:apigateway:" + conan.config.region + ":lambda:path/2015-03-31/functions/" + lambdaArn + aliasSuffix + "/invocations";
 			apiParameters.requestTemplates = requestTemplates;
 		}
 

--- a/es5/lib/plugins/aws-lambda/components/conanAwsLambda.js
+++ b/es5/lib/plugins/aws-lambda/components/conanAwsLambda.js
@@ -46,6 +46,22 @@ var _stepsUpsertLambdaStepJs = require("../steps/upsertLambdaStep.js");
 
 var _stepsUpsertLambdaStepJs2 = _interopRequireDefault(_stepsUpsertLambdaStepJs);
 
+var _stepsPublishLambdaVersionStepJs = require("../steps/publishLambdaVersionStep.js");
+
+var _stepsPublishLambdaVersionStepJs2 = _interopRequireDefault(_stepsPublishLambdaVersionStepJs);
+
+var _stepsFindLambdaAliasStepJs = require("../steps/findLambdaAliasStep.js");
+
+var _stepsFindLambdaAliasStepJs2 = _interopRequireDefault(_stepsFindLambdaAliasStepJs);
+
+var _stepsCreateLambdaAliasStepJs = require("../steps/createLambdaAliasStep.js");
+
+var _stepsCreateLambdaAliasStepJs2 = _interopRequireDefault(_stepsCreateLambdaAliasStepJs);
+
+var _stepsUpdateLambdaAliasStepJs = require("../steps/updateLambdaAliasStep.js");
+
+var _stepsUpdateLambdaAliasStepJs2 = _interopRequireDefault(_stepsUpdateLambdaAliasStepJs);
+
 var ConanAwsLambda = (function (_ConanComponent) {
 	_inherits(ConanAwsLambda, _ConanComponent);
 
@@ -64,7 +80,7 @@ var ConanAwsLambda = (function (_ConanComponent) {
 
 			this.multipleValueParameters("handler");
 
-			this.multipleValueAggregateParameters("dependencies");
+			this.multipleValueAggregateParameters("dependencies", "alias");
 
 			this.name(name);
 			this.filePath(filePath);
@@ -83,6 +99,10 @@ var ConanAwsLambda = (function (_ConanComponent) {
 			this.conan.steps.add(_stepsBuildPackageStepJs2["default"], this);
 			this.conan.steps.add(_stepsCompileLambdaZipStepJs2["default"], this);
 			this.conan.steps.add(_stepsUpsertLambdaStepJs2["default"], this);
+			this.conan.steps.add(_stepsPublishLambdaVersionStepJs2["default"], this);
+			this.conan.steps.add(_stepsFindLambdaAliasStepJs2["default"], this);
+			this.conan.steps.add(_stepsCreateLambdaAliasStepJs2["default"], this);
+			this.conan.steps.add(_stepsUpdateLambdaAliasStepJs2["default"], this);
 		}
 	}, {
 		key: "lambda",

--- a/es5/lib/plugins/aws-lambda/spec/components/conanAwsLambda.spec.js
+++ b/es5/lib/plugins/aws-lambda/spec/components/conanAwsLambda.spec.js
@@ -86,7 +86,7 @@ describe("ConanAwsLambda(conan, name, filePath, role)", function () {
 	});
 
 	describe("(multiple-value-aggregate parameters)", function () {
-		["dependencies"].forEach(function (parameterName) {
+		["dependencies", "alias"].forEach(function (parameterName) {
 			var parameterNamePascalCase = (0, _jargon2["default"])(parameterName).pascal.toString();
 
 			describe("." + parameterName + "(new" + parameterNamePascalCase + ")", function () {
@@ -154,8 +154,28 @@ describe("ConanAwsLambda(conan, name, filePath, role)", function () {
 			step.parameters.should.eql(lambda);
 		});
 
-		it("should add an upsert lambda step step", function () {
+		it("should add an upsert lambda step", function () {
 			var step = conan.steps.findByName("upsertLambdaStep");
+			step.parameters.should.eql(lambda);
+		});
+
+		it("should add an publish lambda version step", function () {
+			var step = conan.steps.findByName("publishLambdaVersionStep");
+			step.parameters.should.eql(lambda);
+		});
+
+		it("should add an find lambda alias step", function () {
+			var step = conan.steps.findByName("findLambdaAliasStep");
+			step.parameters.should.eql(lambda);
+		});
+
+		it("should add an create lambda alias step", function () {
+			var step = conan.steps.findByName("createLambdaAliasStep");
+			step.parameters.should.eql(lambda);
+		});
+
+		it("should add an update lambda alias step", function () {
+			var step = conan.steps.findByName("updateLambdaAliasStep");
 			step.parameters.should.eql(lambda);
 		});
 	});

--- a/es5/lib/plugins/aws-lambda/spec/steps/createLambdaAliasStep.spec.js
+++ b/es5/lib/plugins/aws-lambda/spec/steps/createLambdaAliasStep.spec.js
@@ -1,0 +1,296 @@
+"use strict";
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _conanJs = require("../../../../conan.js");
+
+var _conanJs2 = _interopRequireDefault(_conanJs);
+
+var _stepsCreateLambdaAliasStepJs = require("../../steps/createLambdaAliasStep.js");
+
+var _stepsCreateLambdaAliasStepJs2 = _interopRequireDefault(_stepsCreateLambdaAliasStepJs);
+
+var _sinon = require("sinon");
+
+var _sinon2 = _interopRequireDefault(_sinon);
+
+describe(".createLambdaAliasStep(conan, context, stepDone)", function () {
+	var conan = undefined,
+	    context = undefined,
+	    stepDone = undefined,
+	    awsResponseError = undefined,
+	    aliasArn = undefined,
+	    functionVersion = undefined,
+	    responseData = undefined,
+	    stepReturnError = undefined,
+	    stepReturnData = undefined,
+	    parameters = undefined;
+
+	var mockLambda = {
+		createAlias: _sinon2["default"].spy(function (params, callback) {
+			callback(awsResponseError, responseData(params));
+		})
+	};
+
+	var MockAWS = {
+		Lambda: _sinon2["default"].spy(function () {
+			return mockLambda;
+		})
+	};
+
+	beforeEach(function () {
+		conan = new _conanJs2["default"]({
+			region: "us-east-1"
+		});
+
+		parameters = new ((function () {
+			function MockConanAwsLambda() {
+				_classCallCheck(this, MockConanAwsLambda);
+			}
+
+			_createClass(MockConanAwsLambda, [{
+				key: "name",
+				value: function name() {
+					return "TestFunction";
+				}
+			}, {
+				key: "alias",
+				value: function alias() {
+					return [["development"], ["production", "1"]];
+				}
+			}]);
+
+			return MockConanAwsLambda;
+		})())();
+
+		aliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:alias";
+		functionVersion = "version";
+
+		context = {
+			parameters: parameters,
+			libraries: { AWS: MockAWS },
+			results: {}
+		};
+
+		awsResponseError = null;
+
+		responseData = _sinon2["default"].stub();
+		responseData.returns({ AliasArn: aliasArn, FunctionVersion: functionVersion });
+	});
+
+	describe("(When calling AWS)", function () {
+		beforeEach(function (done) {
+			stepDone = function (afterStepCallback) {
+				return function (error, data) {
+					stepReturnError = error;
+					stepReturnData = data;
+					afterStepCallback();
+				};
+			};
+
+			(0, _stepsCreateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+		});
+
+		it("should be a function", function () {
+			(typeof _stepsCreateLambdaAliasStepJs2["default"]).should.equal("function");
+		});
+
+		it("should set the designated region on the lambda client", function () {
+			MockAWS.Lambda.calledWith({
+				region: conan.config.region
+			}).should.be["true"];
+		});
+
+		it("should call AWS with the designated function name parameter", function () {
+			mockLambda.createAlias.calledWith({
+				"FunctionName": context.parameters.name(),
+				"FunctionVersion": "$LATEST",
+				"Description": "conan auto created alias",
+				"Name": "development"
+			}).should.be["true"];
+		});
+
+		describe("(Alias Create Request for Every Alias)", function () {
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development-all"], ["production-all", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {}
+				};
+				(0, _stepsCreateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({
+					aliases: {
+						"development-all": {
+							aliasArn: aliasArn,
+							functionVersion: functionVersion
+						},
+						"production-all": {
+							aliasArn: aliasArn,
+							functionVersion: functionVersion
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias Create Request for Some Alias)", function () {
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development-some"], ["production-some", "2"], ["staging-some", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-some": {
+								aliasArn: aliasArn,
+								functionVersion: "$LATEST"
+							},
+							"staging-some": {
+								aliasArn: aliasArn
+							}
+						}
+					}
+				};
+				(0, _stepsCreateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({
+					aliases: {
+						"production-some": {
+							aliasArn: aliasArn,
+							functionVersion: functionVersion
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias No Create Request made)", function () {
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "alias",
+						value: function alias() {
+							return [["development"], ["production", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development": { aliasArn: aliasArn, functionVersion: functionVersion },
+							"production": { aliasArn: aliasArn, functionVersion: functionVersion }
+						}
+					}
+				};
+				(0, _stepsCreateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({ aliases: {} });
+			});
+		});
+
+		describe("(Unknown Error is Returned)", function () {
+			var errorMessage = undefined;
+
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development-some"], ["production-some", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-some": { aliasArn: aliasArn, functionVersion: functionVersion }
+						}
+					}
+				};
+				errorMessage = "AWS returned status code 401";
+				awsResponseError = { statusCode: 401, message: errorMessage };
+				mockLambda.createAlias = _sinon2["default"].spy(function (params, callback) {
+					callback(awsResponseError, null);
+				});
+				(0, _stepsCreateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return an error which stops the step runner", function () {
+				stepReturnError.message.should.eql(errorMessage);
+			});
+		});
+	});
+});

--- a/es5/lib/plugins/aws-lambda/spec/steps/findLambdaAliasStep.spec.js
+++ b/es5/lib/plugins/aws-lambda/spec/steps/findLambdaAliasStep.spec.js
@@ -1,0 +1,300 @@
+"use strict";
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _conanJs = require("../../../../conan.js");
+
+var _conanJs2 = _interopRequireDefault(_conanJs);
+
+var _stepsFindLambdaAliasStepJs = require("../../steps/findLambdaAliasStep.js");
+
+var _stepsFindLambdaAliasStepJs2 = _interopRequireDefault(_stepsFindLambdaAliasStepJs);
+
+var _sinon = require("sinon");
+
+var _sinon2 = _interopRequireDefault(_sinon);
+
+var _chai = require("chai");
+
+var _chai2 = _interopRequireDefault(_chai);
+
+describe(".findLambdaAliasStep(conan, context, stepDone)", function () {
+	var conan = undefined,
+	    should = undefined,
+	    context = undefined,
+	    stepDone = undefined,
+	    awsResponseError = undefined,
+	    firstAliasArn = undefined,
+	    secondAliasArn = undefined,
+	    responseData = undefined,
+	    stepReturnError = undefined,
+	    stepReturnData = undefined,
+	    parameters = undefined;
+
+	var mockLambda = {
+		getAlias: _sinon2["default"].spy(function (params, callback) {
+			callback(awsResponseError, responseData(params));
+		})
+	};
+
+	var MockAWS = {
+		Lambda: _sinon2["default"].spy(function () {
+			return mockLambda;
+		})
+	};
+
+	beforeEach(function () {
+		should = _chai2["default"].should();
+		conan = new _conanJs2["default"]({
+			region: "us-east-1"
+		});
+
+		parameters = new ((function () {
+			function MockConanAwsLambda() {
+				_classCallCheck(this, MockConanAwsLambda);
+			}
+
+			_createClass(MockConanAwsLambda, [{
+				key: "name",
+				value: function name() {
+					return "TestFunction";
+				}
+			}, {
+				key: "alias",
+				value: function alias() {
+					return [["development"], ["production", "1"]];
+				}
+			}]);
+
+			return MockConanAwsLambda;
+		})())();
+
+		context = {
+			parameters: parameters,
+			libraries: { AWS: MockAWS },
+			results: {}
+		};
+
+		// "Role Found" response by default
+		firstAliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:development";
+		secondAliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:production";
+
+		awsResponseError = null;
+
+		responseData = _sinon2["default"].stub();
+		responseData.withArgs({ FunctionName: "TestFunction", Name: "development" }).returns({});
+
+		responseData.withArgs({ FunctionName: "TestFunction", Name: "production" }).returns({});
+
+		responseData.withArgs({ FunctionName: "TestFunction", Name: "development-some" }).returns({
+			AliasArn: firstAliasArn,
+			FunctionVersion: "$LATEST"
+		});
+
+		responseData.withArgs({ FunctionName: "TestFunction", Name: "production-some" }).returns({
+			AliasArn: secondAliasArn,
+			FunctionVersion: "2"
+		});
+
+		responseData.withArgs({ FunctionName: "TestFunction", Name: "development-all" }).returns({
+			AliasArn: firstAliasArn,
+			FunctionVersion: "$LATEST"
+		});
+
+		responseData.withArgs({ FunctionName: "TestFunction", Name: "production-all" }).returns({
+			AliasArn: secondAliasArn,
+			FunctionVersion: "1"
+		});
+	});
+
+	describe("(When calling AWS)", function () {
+		beforeEach(function (done) {
+			stepDone = function (afterStepCallback) {
+				return function (error, data) {
+					stepReturnError = error;
+					stepReturnData = data;
+					afterStepCallback();
+				};
+			};
+
+			(0, _stepsFindLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+		});
+
+		it("should be a function", function () {
+			(typeof _stepsFindLambdaAliasStepJs2["default"]).should.equal("function");
+		});
+
+		it("should set the designated region on the lambda client", function () {
+			MockAWS.Lambda.calledWith({
+				region: conan.config.region
+			}).should.be["true"];
+		});
+
+		it("should call AWS with the designated function name parameter", function () {
+			mockLambda.getAlias.calledWith({
+				"FunctionName": context.parameters.name(),
+				"Name": "development"
+			}).should.be["true"];
+		});
+
+		describe("(Alias is Found and Updated for Every Alias)", function () {
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development-all"], ["production-all", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {}
+				};
+				(0, _stepsFindLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({
+					aliases: {
+						"development-all": {
+							aliasArn: firstAliasArn,
+							functionVersion: "$LATEST"
+						},
+						"production-all": {
+							aliasArn: secondAliasArn,
+							functionVersion: "1"
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias is Found but Updated just for Some Alias)", function () {
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development-some"], ["production-some", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {}
+				};
+				(0, _stepsFindLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({
+					aliases: {
+						"development-some": {
+							aliasArn: firstAliasArn,
+							functionVersion: "$LATEST"
+						},
+						"production-some": {
+							aliasArn: secondAliasArn
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias is not Found)", function () {
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development"], ["production", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {}
+				};
+				(0, _stepsFindLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({ aliases: {} });
+			});
+		});
+
+		describe("(Not Found is Returned)", function () {
+			var errorMessage = undefined;
+
+			beforeEach(function () {
+				errorMessage = "AWS returned status code 404";
+				awsResponseError = { statusCode: 404, message: errorMessage };
+			});
+
+			it("should skip the alias because it does not exist", function (done) {
+				(0, _stepsFindLambdaAliasStepJs2["default"])(conan, context, function (error) {
+					should.not.exist(error);
+					done();
+				});
+			});
+		});
+
+		describe("(Unknown Error is Returned)", function () {
+			var errorMessage = undefined;
+
+			beforeEach(function (done) {
+				errorMessage = "AWS returned status code 401";
+				awsResponseError = { statusCode: 401, message: errorMessage };
+				(0, _stepsFindLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return an error which stops the step runner", function () {
+				stepReturnError.message.should.eql(errorMessage);
+			});
+		});
+	});
+});

--- a/es5/lib/plugins/aws-lambda/spec/steps/findLambdaByNameStep.spec.js
+++ b/es5/lib/plugins/aws-lambda/spec/steps/findLambdaByNameStep.spec.js
@@ -22,7 +22,6 @@ describe(".findLambdaByNameStep(conan, context, stepDone)", function () {
 	var conan = undefined,
 	    context = undefined,
 	    stepDone = undefined,
-	    should = undefined,
 	    awsResponseError = undefined,
 	    awsResponseData = undefined,
 	    stepReturnError = undefined,
@@ -121,7 +120,7 @@ describe(".findLambdaByNameStep(conan, context, stepDone)", function () {
 				_createClass(MockConanAwsLambda, [{
 					key: "lambda",
 					value: function lambda() {
-						return null;
+						return [];
 					}
 				}]);
 
@@ -163,7 +162,7 @@ describe(".findLambdaByNameStep(conan, context, stepDone)", function () {
 				_createClass(MockConanAwsLambda, [{
 					key: "lambda",
 					value: function lambda() {
-						return "TestFunctionWithLambda";
+						return ["TestFunctionWithLambda"];
 					}
 				}]);
 

--- a/es5/lib/plugins/aws-lambda/spec/steps/publishLambdaVersionStep.spec.js
+++ b/es5/lib/plugins/aws-lambda/spec/steps/publishLambdaVersionStep.spec.js
@@ -1,0 +1,128 @@
+"use strict";
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _conanJs = require("../../../../conan.js");
+
+var _conanJs2 = _interopRequireDefault(_conanJs);
+
+var _stepsPublishLambdaVersionStepJs = require("../../steps/publishLambdaVersionStep.js");
+
+var _stepsPublishLambdaVersionStepJs2 = _interopRequireDefault(_stepsPublishLambdaVersionStepJs);
+
+var _sinon = require("sinon");
+
+var _sinon2 = _interopRequireDefault(_sinon);
+
+describe(".publishLambdaVersionStep(conan, context, stepDone)", function () {
+	var conan = undefined,
+	    context = undefined,
+	    stepDone = undefined,
+	    awsResponseError = undefined,
+	    awsResponseData = undefined,
+	    stepReturnError = undefined,
+	    stepReturnData = undefined,
+	    parameters = undefined;
+
+	var mockLambda = {
+		publishVersion: _sinon2["default"].spy(function (params, callback) {
+			callback(awsResponseError, awsResponseData);
+		})
+	};
+
+	var MockAWS = {
+		Lambda: _sinon2["default"].spy(function () {
+			return mockLambda;
+		})
+	};
+
+	beforeEach(function () {
+		conan = new _conanJs2["default"]({
+			region: "us-east-1"
+		});
+
+		parameters = new ((function () {
+			function MockConanAwsLambda() {
+				_classCallCheck(this, MockConanAwsLambda);
+			}
+
+			_createClass(MockConanAwsLambda, [{
+				key: "name",
+				value: function name() {
+					return "TestFunction";
+				}
+			}]);
+
+			return MockConanAwsLambda;
+		})())();
+
+		context = {
+			parameters: parameters,
+			libraries: { AWS: MockAWS },
+			results: {}
+		};
+
+		// "Role Found" response by default
+		awsResponseData = {
+			Version: "1"
+		};
+		awsResponseError = null;
+	});
+
+	describe("(When calling AWS)", function () {
+		beforeEach(function (done) {
+			stepDone = function (afterStepCallback) {
+				return function (error, data) {
+					stepReturnError = error;
+					stepReturnData = data;
+					afterStepCallback();
+				};
+			};
+
+			(0, _stepsPublishLambdaVersionStepJs2["default"])(conan, context, stepDone(done));
+		});
+
+		it("should be a function", function () {
+			(typeof _stepsPublishLambdaVersionStepJs2["default"]).should.equal("function");
+		});
+
+		it("should set the designated region on the lambda client", function () {
+			MockAWS.Lambda.calledWith({
+				region: conan.config.region
+			}).should.be["true"];
+		});
+
+		it("should call AWS with the designated function name parameter", function () {
+			mockLambda.publishVersion.calledWith({
+				"FunctionName": context.parameters.name(),
+				"Description": "conan autopublish step"
+			}).should.be["true"];
+		});
+
+		describe("(Version is Published)", function () {
+			it("should return the version number", function () {
+				stepReturnData.should.eql({
+					lambdaVersion: awsResponseData.Version
+				});
+			});
+		});
+
+		describe("(Unknown Error is Returned)", function () {
+			var errorMessage = undefined;
+
+			beforeEach(function (done) {
+				errorMessage = "AWS returned status code 401";
+				awsResponseError = { statusCode: 401, message: errorMessage };
+				(0, _stepsPublishLambdaVersionStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return an error which stops the step runner", function () {
+				stepReturnError.message.should.eql(errorMessage);
+			});
+		});
+	});
+});

--- a/es5/lib/plugins/aws-lambda/spec/steps/updateLambdaAliasStep.spec.js
+++ b/es5/lib/plugins/aws-lambda/spec/steps/updateLambdaAliasStep.spec.js
@@ -1,0 +1,324 @@
+"use strict";
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _conanJs = require("../../../../conan.js");
+
+var _conanJs2 = _interopRequireDefault(_conanJs);
+
+var _stepsUpdateLambdaAliasStepJs = require("../../steps/updateLambdaAliasStep.js");
+
+var _stepsUpdateLambdaAliasStepJs2 = _interopRequireDefault(_stepsUpdateLambdaAliasStepJs);
+
+var _sinon = require("sinon");
+
+var _sinon2 = _interopRequireDefault(_sinon);
+
+describe(".updateLambdaAliasStep(conan, context, stepDone)", function () {
+	var conan = undefined,
+	    context = undefined,
+	    stepDone = undefined,
+	    awsResponseError = undefined,
+	    aliasArn = undefined,
+	    functionVersion = undefined,
+	    responseData = undefined,
+	    stepReturnError = undefined,
+	    stepReturnData = undefined,
+	    parameters = undefined;
+
+	var mockLambda = {
+		updateAlias: _sinon2["default"].spy(function (params, callback) {
+			callback(awsResponseError, responseData(params));
+		})
+	};
+
+	var MockAWS = {
+		Lambda: _sinon2["default"].spy(function () {
+			return mockLambda;
+		})
+	};
+
+	beforeEach(function () {
+		conan = new _conanJs2["default"]({
+			region: "us-east-1"
+		});
+
+		parameters = new ((function () {
+			function MockConanAwsLambda() {
+				_classCallCheck(this, MockConanAwsLambda);
+			}
+
+			_createClass(MockConanAwsLambda, [{
+				key: "name",
+				value: function name() {
+					return "TestFunction";
+				}
+			}, {
+				key: "alias",
+				value: function alias() {
+					return [["development"], ["production", "1"]];
+				}
+			}]);
+
+			return MockConanAwsLambda;
+		})())();
+
+		aliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:alias";
+		functionVersion = "version";
+
+		context = {
+			parameters: parameters,
+			libraries: { AWS: MockAWS },
+			results: {
+				aliases: {
+					"development": {},
+					"production": {}
+				}
+			}
+		};
+
+		awsResponseError = null;
+
+		responseData = _sinon2["default"].stub();
+		responseData.returns({ AliasArn: aliasArn, FunctionVersion: functionVersion });
+	});
+
+	describe("(When calling AWS)", function () {
+		beforeEach(function (done) {
+			stepDone = function (afterStepCallback) {
+				return function (error, data) {
+					stepReturnError = error;
+					stepReturnData = data;
+					afterStepCallback();
+				};
+			};
+
+			(0, _stepsUpdateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+		});
+
+		it("should be a function", function () {
+			(typeof _stepsUpdateLambdaAliasStepJs2["default"]).should.equal("function");
+		});
+
+		it("should set the designated region on the lambda client", function () {
+			MockAWS.Lambda.calledWith({
+				region: conan.config.region
+			}).should.be["true"];
+		});
+
+		it("should call AWS with the designated function name parameter", function () {
+			mockLambda.updateAlias.calledWith({
+				"FunctionName": context.parameters.name(),
+				"FunctionVersion": "$LATEST",
+				"Description": "conan auto updated alias",
+				"Name": "development"
+			}).should.be["true"];
+		});
+
+		describe("(Alias Update Request for Every Alias)", function () {
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development-all"], ["production-all", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-all": {
+								aliasArn: aliasArn
+							},
+							"production-all": {
+								aliasArn: aliasArn
+							}
+						}
+					}
+				};
+				(0, _stepsUpdateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({
+					aliases: {
+						"development-all": {
+							aliasArn: aliasArn,
+							functionVersion: functionVersion
+						},
+						"production-all": {
+							aliasArn: aliasArn,
+							functionVersion: functionVersion
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias Update Request for Some Alias)", function () {
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development-some"], ["production-some", "2"], ["staging-some", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-some": {
+								aliasArn: aliasArn,
+								functionVersion: "version"
+							},
+							"staging-some": {
+								aliasArn: aliasArn
+							},
+							"production-some": {
+								aliasArn: aliasArn
+							}
+						}
+					}
+				};
+				(0, _stepsUpdateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({
+					aliases: {
+						"production-some": {
+							aliasArn: aliasArn,
+							functionVersion: functionVersion
+						},
+						"staging-some": {
+							aliasArn: aliasArn,
+							functionVersion: functionVersion
+						},
+						"development-some": {
+							aliasArn: aliasArn,
+							functionVersion: functionVersion
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias No Update Request made)", function () {
+			var aliases = undefined;
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "alias",
+						value: function alias() {
+							return [["development"], ["production", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+				aliases = {
+					"development": { aliasArn: aliasArn, functionVersion: functionVersion },
+					"production": { aliasArn: aliasArn, functionVersion: functionVersion }
+				};
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: aliases
+					}
+				};
+				(0, _stepsUpdateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", function () {
+				stepReturnData.should.eql({ aliases: aliases });
+			});
+		});
+
+		describe("(Unknown Error is Returned)", function () {
+			var errorMessage = undefined;
+
+			beforeEach(function (done) {
+				parameters = new ((function () {
+					function MockConanAwsLambda() {
+						_classCallCheck(this, MockConanAwsLambda);
+					}
+
+					_createClass(MockConanAwsLambda, [{
+						key: "name",
+						value: function name() {
+							return "TestFunction";
+						}
+					}, {
+						key: "alias",
+						value: function alias() {
+							return [["development-some"], ["production-some", "1"]];
+						}
+					}]);
+
+					return MockConanAwsLambda;
+				})())();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-some": { aliasArn: aliasArn },
+							"production-some": { aliasArn: aliasArn, functionVersion: functionVersion }
+						}
+					}
+				};
+				errorMessage = "AWS returned status code 401";
+				awsResponseError = { statusCode: 401, message: errorMessage };
+				mockLambda.updateAlias = _sinon2["default"].spy(function (params, callback) {
+					callback(awsResponseError, null);
+				});
+				(0, _stepsUpdateLambdaAliasStepJs2["default"])(conan, context, stepDone(done));
+			});
+
+			it("should return an error which stops the step runner", function () {
+				stepReturnError.message.should.eql(errorMessage);
+			});
+		});
+	});
+});

--- a/es5/lib/plugins/aws-lambda/steps/createLambdaAliasStep.js
+++ b/es5/lib/plugins/aws-lambda/steps/createLambdaAliasStep.js
@@ -1,0 +1,61 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+exports["default"] = createLambdaAliasStep;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+var _flowsync = require("flowsync");
+
+var _flowsync2 = _interopRequireDefault(_flowsync);
+
+function createLambdaAliasStep(conan, context, stepDone) {
+	var AWS = context.libraries.AWS;
+	var iam = new AWS.Lambda({
+		region: conan.config.region
+	});
+
+	var aliases = context.parameters.alias();
+	var result = {};
+	_flowsync2["default"].eachSeries(aliases, function (alias, next) {
+		var aliasName = alias[0];
+		var aliasVersion = undefined;
+		if (alias.length > 1) {
+			aliasVersion = alias[1];
+		} else {
+			aliasVersion = "$LATEST";
+		}
+
+		var aliasExists = undefined;
+		if (context.results.aliases) {
+			aliasExists = context.results.aliases[aliasName];
+		}
+
+		if (!aliasExists) {
+			iam.createAlias({
+				"FunctionName": context.parameters.name(),
+				"FunctionVersion": aliasVersion,
+				"Name": aliasName,
+				"Description": "conan auto created alias"
+			}, function (error, responseData) {
+				if (responseData) {
+					result[aliasName] = {
+						aliasArn: responseData.AliasArn,
+						functionVersion: responseData.FunctionVersion
+					};
+					next();
+				} else {
+					next(error);
+				}
+			});
+		} else {
+			next();
+		}
+	}, function (error) {
+		stepDone(error, { aliases: result });
+	});
+}
+
+module.exports = exports["default"];

--- a/es5/lib/plugins/aws-lambda/steps/findLambdaAliasStep.js
+++ b/es5/lib/plugins/aws-lambda/steps/findLambdaAliasStep.js
@@ -1,0 +1,59 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+exports["default"] = findLambdaAliasStep;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+var _flowsync = require("flowsync");
+
+var _flowsync2 = _interopRequireDefault(_flowsync);
+
+function findLambdaAliasStep(conan, context, stepDone) {
+	var AWS = context.libraries.AWS;
+	var iam = new AWS.Lambda({
+		region: conan.config.region
+	});
+
+	var aliases = context.parameters.alias();
+	var result = {};
+	_flowsync2["default"].eachSeries(aliases, function (alias, next) {
+		var aliasName = alias[0];
+		var aliasVersion = undefined;
+		if (alias.length > 1) {
+			aliasVersion = alias[1];
+		} else {
+			aliasVersion = "$LATEST";
+		}
+
+		iam.getAlias({
+			"FunctionName": context.parameters.name(),
+			"Name": aliasName
+		}, function (error, responseData) {
+			if (responseData && responseData.FunctionVersion === aliasVersion) {
+				// alias exists
+				result[aliasName] = {
+					aliasArn: responseData.AliasArn,
+					functionVersion: responseData.FunctionVersion
+				};
+				next();
+			} else if (responseData && responseData.FunctionVersion) {
+				// needs version update
+				result[aliasName] = {
+					aliasArn: responseData.AliasArn
+				};
+				next();
+			} else if (error && error.statusCode === 404) {
+				next();
+			} else {
+				next(error);
+			}
+		});
+	}, function (error) {
+		stepDone(error, { aliases: result });
+	});
+}
+
+module.exports = exports["default"];

--- a/es5/lib/plugins/aws-lambda/steps/findLambdaByNameStep.js
+++ b/es5/lib/plugins/aws-lambda/steps/findLambdaByNameStep.js
@@ -14,7 +14,7 @@ function findLambdaByNameStep(conan, context, stepDone) {
 	if (typeof context.parameters.name === "function") {
 		lambdaName = context.parameters.name();
 	} else {
-		lambdaName = context.parameters.lambda();
+		lambdaName = context.parameters.lambda()[0];
 	}
 
 	if (lambdaName) {

--- a/es5/lib/plugins/aws-lambda/steps/publishLambdaVersionStep.js
+++ b/es5/lib/plugins/aws-lambda/steps/publishLambdaVersionStep.js
@@ -1,0 +1,28 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+exports["default"] = publishLambdaVersionStep;
+
+function publishLambdaVersionStep(conan, context, stepDone) {
+	var AWS = context.libraries.AWS;
+	var iam = new AWS.Lambda({
+		region: conan.config.region
+	});
+
+	iam.publishVersion({
+		"FunctionName": context.parameters.name(),
+		"Description": "conan autopublish step"
+	}, function (error, responseData) {
+		if (error) {
+			stepDone(error);
+		} else {
+			stepDone(null, {
+				lambdaVersion: responseData.Version
+			});
+		}
+	});
+}
+
+module.exports = exports["default"];

--- a/es5/lib/plugins/aws-lambda/steps/updateLambdaAliasStep.js
+++ b/es5/lib/plugins/aws-lambda/steps/updateLambdaAliasStep.js
@@ -1,0 +1,56 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+exports["default"] = updateLambdaAliasStep;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+var _flowsync = require("flowsync");
+
+var _flowsync2 = _interopRequireDefault(_flowsync);
+
+function updateLambdaAliasStep(conan, context, stepDone) {
+	var AWS = context.libraries.AWS;
+	var iam = new AWS.Lambda({
+		region: conan.config.region
+	});
+
+	var aliases = context.parameters.alias();
+	var result = context.results.aliases;
+	_flowsync2["default"].eachSeries(aliases, function (alias, next) {
+		var aliasName = alias[0];
+		var aliasVersion = undefined;
+		if (alias.length > 1) {
+			aliasVersion = alias[1];
+		} else {
+			aliasVersion = "$LATEST";
+		}
+
+		if (context.results.aliases && !context.results.aliases[aliasName].functionVersion) {
+			iam.updateAlias({
+				"FunctionName": context.parameters.name(),
+				"FunctionVersion": aliasVersion,
+				"Name": aliasName,
+				"Description": "conan auto updated alias"
+			}, function (error, responseData) {
+				if (responseData) {
+					result[aliasName] = {
+						aliasArn: responseData.AliasArn,
+						functionVersion: responseData.FunctionVersion
+					};
+					next();
+				} else {
+					next(error);
+				}
+			});
+		} else {
+			next();
+		}
+	}, function (error) {
+		stepDone(error, { aliases: result });
+	});
+}
+
+module.exports = exports["default"];

--- a/es5/lib/plugins/aws-lambda/steps/updateLambdaAliasStep.js
+++ b/es5/lib/plugins/aws-lambda/steps/updateLambdaAliasStep.js
@@ -28,7 +28,7 @@ function updateLambdaAliasStep(conan, context, stepDone) {
 			aliasVersion = "$LATEST";
 		}
 
-		if (context.results.aliases && !context.results.aliases[aliasName].functionVersion) {
+		if (context.results.aliases && context.results.aliases[aliasName] && !context.results.aliases[aliasName].functionVersion) {
 			iam.updateAlias({
 				"FunctionName": context.parameters.name(),
 				"FunctionVersion": aliasVersion,

--- a/es6/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayResource.js
+++ b/es6/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayResource.js
@@ -20,12 +20,12 @@ export default class ConanAwsApiGatewayResource extends ConanComponent {
 		this.parameters(
 			"path",
 			"method",
-			"lambda",
 			"statusCodes",
 			"responseHeaders"
 		);
 
 		this.multipleValueParameters(
+			"lambda",
 			"headers",
 			"queryStrings"
 		);

--- a/es6/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayResource.js
+++ b/es6/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayResource.js
@@ -43,9 +43,9 @@ export default class ConanAwsApiGatewayResource extends ConanComponent {
 		this.conan.steps.before(findApiStageByNameStep, findResourceMethodStep, this);
 		this.conan.steps.before(findApiStageByNameStep, createResourceMethodStep, this);
 		this.conan.steps.before(findApiStageByNameStep, putIntegrationStep, this);
-		this.conan.steps.before(findApiStageByNameStep, putIntegrationResponseStep, this);
 		this.conan.steps.before(findApiStageByNameStep, findMethodResponseStep, this);
 		this.conan.steps.before(findApiStageByNameStep, putMethodResponseStep, this);
+		this.conan.steps.before(findApiStageByNameStep, putIntegrationResponseStep, this);
 		this.conan.steps.before(findApiStageByNameStep, getAccountIdStep, this);
 		this.conan.steps.before(findApiStageByNameStep, addPermissionStep, this);
 	}

--- a/es6/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayStage.js
+++ b/es6/lib/plugins/aws-api-gateway/components/conanAwsApiGatewayStage.js
@@ -41,4 +41,8 @@ export default class ConanAwsApiGatewayStage extends ConanComponent {
 	delete(path) {
 		return new ConanAwsApiGatewayResource(this.conan, path, "DELETE");
 	}
+
+	options(path) {
+		return new ConanAwsApiGatewayResource(this.conan, path, "OPTIONS");
+	}
 }

--- a/es6/lib/plugins/aws-api-gateway/spec/components/conanAwsGatewayApiResource.spec.js
+++ b/es6/lib/plugins/aws-api-gateway/spec/components/conanAwsGatewayApiResource.spec.js
@@ -31,7 +31,6 @@ describe("ConanAwsApiGatewayResource(conan)", () => {
 		[
 			"path",
 			"method",
-			"lambda",
 			"statusCodes",
 			"responseHeaders"
 		].forEach((parameterName) => {
@@ -51,6 +50,7 @@ describe("ConanAwsApiGatewayResource(conan)", () => {
 	describe("(multiple-value parameters)", () => {
 		[
 			"headers",
+			"lambda",
 			"queryStrings"
 		].forEach((parameterName) => {
 			const parameterNamePascalCase = inflect(parameterName).pascal.toString();

--- a/es6/lib/plugins/aws-api-gateway/spec/components/conanAwsGatewayApiStage.spec.js
+++ b/es6/lib/plugins/aws-api-gateway/spec/components/conanAwsGatewayApiStage.spec.js
@@ -86,7 +86,8 @@ describe("ConanAwsApiGatewayStage(conan, name)", () => {
 		"GET",
 		"POST",
 		"PUT",
-		"DELETE"
+		"DELETE",
+		"OPTIONS"
 	].forEach((resourceMethod) => {
 		const methodFunctionName = resourceMethod.toLowerCase();
 		describe(`stage.${methodFunctionName}(path)`, () => {

--- a/es6/lib/plugins/aws-api-gateway/spec/steps/putIntegrationStep.spec.js
+++ b/es6/lib/plugins/aws-api-gateway/spec/steps/putIntegrationStep.spec.js
@@ -42,6 +42,7 @@ describe("putIntegrationStep", () => {
 			path() { return "/account/items"; }
 			headers() { return []; }
 			queryStrings() { return []; }
+			lambda() { return []; }
 		}();
 
 
@@ -82,6 +83,7 @@ describe("putIntegrationStep", () => {
 					method() { return "GET"; }
 					headers() { return ["Access-Token"]; }
 					queryStrings() { return []; }
+					lambda() { return []; }
 				}();
 				requestTemplates = {"application/json": "{\n  \"params\": {\n \"header\": {\n\"accessToken\": \"$input.params('Access-Token')\"\n},\n \"queryString\": {\n},\n \"path\": {\n}},\n \"data\": $input.json('$')\n}"};
 				putIntegrationStep(conan, context, () => {
@@ -101,6 +103,7 @@ describe("putIntegrationStep", () => {
 					path() { return "/accounts/items"; }
 					headers() { return []; }
 					queryStrings() { return ["pageSize"]; }
+					lambda() { return []; }
 				}();
 				requestTemplates = {"application/json": "{\n  \"params\": {\n \"header\": {\n},\n \"queryString\": {\n\"pageSize\": \"$input.params('pageSize')\"\n},\n \"path\": {\n}},\n \"data\": $input.json('$')\n}"};
 				putIntegrationStep(conan, context, () => {
@@ -120,6 +123,7 @@ describe("putIntegrationStep", () => {
 					path() { return "/account/{id}"; }
 					headers() { return []; }
 					queryStrings() { return []; }
+					lambda() { return []; }
 				}();
 				requestTemplates = {"application/json": "{\n  \"params\": {\n \"header\": {\n},\n \"queryString\": {\n},\n \"path\": {\n\"id\": \"$input.params('id')\"\n}},\n \"data\": $input.json('$')\n}"};
 				putIntegrationStep(conan, context, () => {
@@ -177,11 +181,32 @@ describe("putIntegrationStep", () => {
 		});
 	});
 
-	describe("(resource method created with version)", () => {
+	describe("(resource method created with alias)", () => {
 		let responseData;
 
 		beforeEach(() => {
+			parameters = new class MockConanAwsParameters {
+				method() { return "GET"; }
+				path() { return "/account/items"; }
+				headers() { return []; }
+				queryStrings() { return []; }
+				lambda() { return ["testFunction", "development"]; }
+			}();
+			context = {
+				parameters,
+				results: {
+					restApiId,
+					apiResourceId,
+					lambdaArn
+				},
+				libraries: {
+					AWS: {
+						APIGateway
+					}
+				}
+			};
 			responseData = {};
+			uri = `arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/${lambdaArn}:development/invocations`;
 			putIntegrationSpy = sinon.spy((awsParameters, callback) => {
 				callback(null, responseData);
 			});
@@ -190,6 +215,21 @@ describe("putIntegrationStep", () => {
 		it("should return with no error", done => {
 			putIntegrationStep(conan, context, (error) => {
 				should.not.exist(error);
+				done();
+			});
+		});
+
+		it("should use the alias on the uri", done => {
+			putIntegrationStep(conan, context, () => {
+				putIntegrationSpy.firstCall.args[0].should.eql({
+					resourceId: apiResourceId,
+					httpMethod: parameters.method(),
+					type: "AWS",
+					integrationHttpMethod: "POST",
+					uri,
+					requestTemplates,
+					restApiId
+				});
 				done();
 			});
 		});

--- a/es6/lib/plugins/aws-api-gateway/spec/steps/putIntegrationStep.spec.js
+++ b/es6/lib/plugins/aws-api-gateway/spec/steps/putIntegrationStep.spec.js
@@ -177,6 +177,24 @@ describe("putIntegrationStep", () => {
 		});
 	});
 
+	describe("(resource method created with version)", () => {
+		let responseData;
+
+		beforeEach(() => {
+			responseData = {};
+			putIntegrationSpy = sinon.spy((awsParameters, callback) => {
+				callback(null, responseData);
+			});
+		});
+
+		it("should return with no error", done => {
+			putIntegrationStep(conan, context, (error) => {
+				should.not.exist(error);
+				done();
+			});
+		});
+	});
+
 	describe("(rest api id is not present)", () => {
 		beforeEach(() => {
 			delete context.results.restApiId;

--- a/es6/lib/plugins/aws-api-gateway/steps/addPermissionStep.js
+++ b/es6/lib/plugins/aws-api-gateway/steps/addPermissionStep.js
@@ -13,7 +13,7 @@ export default function addPermissionStep(conan, context, stepDone) {
 		&& typeof context.parameters.path === "function"
 		&& accountId
 		&& restApiId) {
-		const lambdaName = context.parameters.lambda();
+		const lambdaName = context.parameters.lambda()[0];
 		const method = context.parameters.method();
 		const path = context.parameters.path();
 		if(lambdaName) {
@@ -37,13 +37,17 @@ export default function addPermissionStep(conan, context, stepDone) {
 					}
 				}
 				if(!statement) {
-					lambda.addPermission({
+					const apiParameters = {
 						"FunctionName": lambdaName,
 						"SourceArn": sourceArn,
 						"Action": "lambda:InvokeFunction",
 						"Principal": "apigateway.amazonaws.com",
 						"StatementId": hacher.getUUID()
-					}, (error) => {
+					};
+					if(context.parameters.lambda().length > 1) {
+						apiParameters.Qualifier = context.parameters.lambda()[1];
+					}
+					lambda.addPermission(apiParameters, (error) => {
 						if (error && error.statusCode === 409) {
 							stepDone(null);
 						} else if (error) {

--- a/es6/lib/plugins/aws-api-gateway/steps/putIntegrationStep.js
+++ b/es6/lib/plugins/aws-api-gateway/steps/putIntegrationStep.js
@@ -46,8 +46,12 @@ export default function putIntegrationStep(conan, context, done) {
 		};
 
 		if(lambdaArn) {
+			let aliasSuffix = "";
+			if(context.parameters.lambda().length > 1) {
+				aliasSuffix = `:${context.parameters.lambda()[1]}`;
+			}
 			apiParameters.type = "AWS";
-			apiParameters.uri = `arn:aws:apigateway:${conan.config.region}:lambda:path/2015-03-31/functions/${lambdaArn}/invocations`;
+			apiParameters.uri = `arn:aws:apigateway:${conan.config.region}:lambda:path/2015-03-31/functions/${lambdaArn}${aliasSuffix}/invocations`;
 			apiParameters.requestTemplates = requestTemplates;
 		}
 

--- a/es6/lib/plugins/aws-lambda/components/conanAwsLambda.js
+++ b/es6/lib/plugins/aws-lambda/components/conanAwsLambda.js
@@ -8,6 +8,8 @@ import compileLambdaZipStep from "../steps/compileLambdaZipStep.js";
 import upsertLambdaStep from "../steps/upsertLambdaStep.js";
 import publishLambdaVersionStep from "../steps/publishLambdaVersionStep.js";
 import findLambdaAliasStep from "../steps/findLambdaAliasStep.js";
+import createLambdaAliasStep from "../steps/createLambdaAliasStep.js";
+import updateLambdaAliasStep from "../steps/updateLambdaAliasStep.js";
 
 export default class ConanAwsLambda extends ConanComponent {
 	initialize(conan, name, filePath, role) {
@@ -54,6 +56,8 @@ export default class ConanAwsLambda extends ConanComponent {
 		this.conan.steps.add(upsertLambdaStep, this);
 		this.conan.steps.add(publishLambdaVersionStep, this);
 		this.conan.steps.add(findLambdaAliasStep, this);
+		this.conan.steps.add(createLambdaAliasStep, this);
+		this.conan.steps.add(updateLambdaAliasStep, this);
 	}
 
 	lambda(name) {

--- a/es6/lib/plugins/aws-lambda/components/conanAwsLambda.js
+++ b/es6/lib/plugins/aws-lambda/components/conanAwsLambda.js
@@ -6,6 +6,8 @@ import attachRolePolicyStep from "../steps/attachRolePolicyStep.js";
 import buildPackageStep from "../steps/buildPackageStep.js";
 import compileLambdaZipStep from "../steps/compileLambdaZipStep.js";
 import upsertLambdaStep from "../steps/upsertLambdaStep.js";
+import publishLambdaVersionStep from "../steps/publishLambdaVersionStep.js";
+import findLambdaAliasStep from "../steps/findLambdaAliasStep.js";
 
 export default class ConanAwsLambda extends ConanComponent {
 	initialize(conan, name, filePath, role) {
@@ -29,7 +31,8 @@ export default class ConanAwsLambda extends ConanComponent {
 		);
 
 		this.multipleValueAggregateParameters(
-			"dependencies"
+			"dependencies",
+			"alias"
 		);
 
 		this.name(name);
@@ -49,6 +52,8 @@ export default class ConanAwsLambda extends ConanComponent {
 		this.conan.steps.add(buildPackageStep, this);
 		this.conan.steps.add(compileLambdaZipStep, this);
 		this.conan.steps.add(upsertLambdaStep, this);
+		this.conan.steps.add(publishLambdaVersionStep, this);
+		this.conan.steps.add(findLambdaAliasStep, this);
 	}
 
 	lambda(name) {

--- a/es6/lib/plugins/aws-lambda/spec/components/conanAwsLambda.spec.js
+++ b/es6/lib/plugins/aws-lambda/spec/components/conanAwsLambda.spec.js
@@ -85,7 +85,8 @@ describe("ConanAwsLambda(conan, name, filePath, role)", () => {
 
 	describe("(multiple-value-aggregate parameters)", () => {
 		[
-			"dependencies"
+			"dependencies",
+			"alias"
 		].forEach((parameterName) => {
 			const parameterNamePascalCase = inflect(parameterName).pascal.toString();
 
@@ -157,8 +158,18 @@ describe("ConanAwsLambda(conan, name, filePath, role)", () => {
 			step.parameters.should.eql(lambda);
 		});
 
-		it("should add an upsert lambda step step", () => {
+		it("should add an upsert lambda step", () => {
 			const step = conan.steps.findByName("upsertLambdaStep");
+			step.parameters.should.eql(lambda);
+		});
+
+		it("should add an publish lambda version step", () => {
+			const step = conan.steps.findByName("publishLambdaVersionStep");
+			step.parameters.should.eql(lambda);
+		});
+
+		it("should add an find lambda alias step", () => {
+			const step = conan.steps.findByName("findLambdaAliasStep");
 			step.parameters.should.eql(lambda);
 		});
 	});

--- a/es6/lib/plugins/aws-lambda/spec/components/conanAwsLambda.spec.js
+++ b/es6/lib/plugins/aws-lambda/spec/components/conanAwsLambda.spec.js
@@ -172,6 +172,16 @@ describe("ConanAwsLambda(conan, name, filePath, role)", () => {
 			const step = conan.steps.findByName("findLambdaAliasStep");
 			step.parameters.should.eql(lambda);
 		});
+
+		it("should add an create lambda alias step", () => {
+			const step = conan.steps.findByName("createLambdaAliasStep");
+			step.parameters.should.eql(lambda);
+		});
+
+		it("should add an update lambda alias step", () => {
+			const step = conan.steps.findByName("updateLambdaAliasStep");
+			step.parameters.should.eql(lambda);
+		});
 	});
 
 	describe(".lambda(name)", () => {

--- a/es6/lib/plugins/aws-lambda/spec/steps/createLambdaAliasStep.spec.js
+++ b/es6/lib/plugins/aws-lambda/spec/steps/createLambdaAliasStep.spec.js
@@ -1,27 +1,25 @@
 import Conan from "../../../../conan.js";
-import findLambdaAliasStep from "../../steps/findLambdaAliasStep.js";
+import createLambdaAliasStep from "../../steps/createLambdaAliasStep.js";
 import sinon from "sinon";
-import chai from "chai";
 
-describe(".findLambdaAliasStep(conan, context, stepDone)", () => {
+describe(".createLambdaAliasStep(conan, context, stepDone)", () => {
 	let conan,
-		should,
-		context,
-		stepDone,
+			context,
+			stepDone,
 
-		awsResponseError,
-		firstAliasArn,
-		secondAliasArn,
+			awsResponseError,
+			aliasArn,
+			functionVersion,
 
-		responseData,
+			responseData,
 
-		stepReturnError,
-		stepReturnData,
+			stepReturnError,
+			stepReturnData,
 
-		parameters;
+			parameters;
 
 	let mockLambda = {
-		getAlias: sinon.spy((params, callback) => {
+		createAlias: sinon.spy((params, callback) => {
 			callback(awsResponseError, responseData(params));
 		})
 	};
@@ -33,7 +31,6 @@ describe(".findLambdaAliasStep(conan, context, stepDone)", () => {
 	};
 
 	beforeEach(() => {
-		should = chai.should();
 		conan = new Conan({
 			region: "us-east-1"
 		});
@@ -43,48 +40,20 @@ describe(".findLambdaAliasStep(conan, context, stepDone)", () => {
 			alias() { return [["development"], ["production", "1"]]; }
 		}();
 
+		aliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:alias";
+		functionVersion = "version";
+
 		context = {
 			parameters: parameters,
 			libraries: { AWS: MockAWS },
-			results: {}
+			results: {
+			}
 		};
-
-		// "Role Found" response by default
-		firstAliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:development";
-		secondAliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:production";
 
 		awsResponseError = null;
 
 		responseData = sinon.stub();
-		responseData.withArgs({FunctionName: "TestFunction", Name: "development"})
-			.returns({});
-
-		responseData.withArgs({FunctionName: "TestFunction", Name: "production"})
-			.returns({});
-
-		responseData.withArgs({FunctionName: "TestFunction", Name: "development-some"})
-			.returns({
-				AliasArn: firstAliasArn,
-				FunctionVersion: "$LATEST"
-			});
-
-		responseData.withArgs({FunctionName: "TestFunction", Name: "production-some"})
-			.returns({
-				AliasArn: secondAliasArn,
-				FunctionVersion: "2"
-			});
-
-		responseData.withArgs({FunctionName: "TestFunction", Name: "development-all"})
-			.returns({
-				AliasArn: firstAliasArn,
-				FunctionVersion: "$LATEST"
-			});
-
-		responseData.withArgs({FunctionName: "TestFunction", Name: "production-all"})
-			.returns({
-				AliasArn: secondAliasArn,
-				FunctionVersion: "1"
-			});
+		responseData.returns({AliasArn: aliasArn, FunctionVersion: functionVersion});
 	});
 
 	describe("(When calling AWS)", () => {
@@ -97,11 +66,11 @@ describe(".findLambdaAliasStep(conan, context, stepDone)", () => {
 				};
 			};
 
-			findLambdaAliasStep(conan, context, stepDone(done));
+			createLambdaAliasStep(conan, context, stepDone(done));
 		});
 
 		it("should be a function", () => {
-			(typeof findLambdaAliasStep).should.equal("function");
+			(typeof createLambdaAliasStep).should.equal("function");
 		});
 
 		it("should set the designated region on the lambda client", () => {
@@ -111,13 +80,15 @@ describe(".findLambdaAliasStep(conan, context, stepDone)", () => {
 		});
 
 		it("should call AWS with the designated function name parameter", () => {
-			mockLambda.getAlias.calledWith({
+			mockLambda.createAlias.calledWith({
 				"FunctionName": context.parameters.name(),
+				"FunctionVersion": "$LATEST",
+				"Description": "conan auto created alias",
 				"Name": "development"
 			}).should.be.true;
 		});
 
-		describe("(Alias is Found and Updated for Every Alias)", () => {
+		describe("(Alias Create Request for Every Alias)", () => {
 			beforeEach(done => {
 				parameters = new class MockConanAwsLambda {
 					name() { return "TestFunction"; }
@@ -129,26 +100,89 @@ describe(".findLambdaAliasStep(conan, context, stepDone)", () => {
 					libraries: { AWS: MockAWS },
 					results: {}
 				};
-				findLambdaAliasStep(conan, context, stepDone(done));
+				createLambdaAliasStep(conan, context, stepDone(done));
 			});
 
 			it("should return the alias arn", () => {
 				stepReturnData.should.eql({
 					aliases: {
 						"development-all": {
-							aliasArn: firstAliasArn,
-							functionVersion: "$LATEST"
+							aliasArn,
+							functionVersion
 						},
 						"production-all": {
-							aliasArn: secondAliasArn,
-							functionVersion: "1"
+							aliasArn,
+							functionVersion
 						}
 					}
 				});
 			});
 		});
 
-		describe("(Alias is Found but Updated just for Some Alias)", () => {
+		describe("(Alias Create Request for Some Alias)", () => {
+			beforeEach(done => {
+				parameters = new class MockConanAwsLambda {
+					name() { return "TestFunction"; }
+					alias() { return [["development-some"], ["production-some", "2"], ["staging-some", "1"]]; }
+				}();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-some": {
+								aliasArn,
+								functionVersion: "$LATEST"
+							},
+							"staging-some": {
+								aliasArn
+							}
+						}
+					}
+				};
+				createLambdaAliasStep(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", () => {
+				stepReturnData.should.eql({
+					aliases: {
+						"production-some": {
+							aliasArn,
+							functionVersion
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias No Create Request made)", () => {
+			beforeEach(done => {
+				parameters = new class MockConanAwsLambda {
+					alias() { return [["development"], ["production", "1"]]; }
+				}();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development": { aliasArn, functionVersion },
+							"production": { aliasArn, functionVersion }
+						}
+					}
+				};
+				createLambdaAliasStep(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", () => {
+				stepReturnData.should.eql({ aliases: {} });
+			});
+		});
+
+		describe("(Unknown Error is Returned)", () => {
+			let errorMessage;
+
 			beforeEach(done => {
 				parameters = new class MockConanAwsLambda {
 					name() { return "TestFunction"; }
@@ -158,69 +192,18 @@ describe(".findLambdaAliasStep(conan, context, stepDone)", () => {
 				context = {
 					parameters: parameters,
 					libraries: { AWS: MockAWS },
-					results: {}
-				};
-				findLambdaAliasStep(conan, context, stepDone(done));
-			});
-
-			it("should return the alias arn", () => {
-				stepReturnData.should.eql({
-					aliases: {
-						"development-some": {
-							aliasArn: firstAliasArn,
-							functionVersion: "$LATEST"
-						},
-						"production-some": {
-							aliasArn: secondAliasArn
+					results: {
+						aliases: {
+							"development-some": { aliasArn, functionVersion }
 						}
 					}
-				});
-			});
-		});
-
-		describe("(Alias is not Found)", () => {
-			beforeEach(done => {
-				parameters = new class MockConanAwsLambda {
-					name() { return "TestFunction"; }
-					alias() { return [["development"], ["production", "1"]]; }
-				}();
-
-				context = {
-					parameters: parameters,
-					libraries: { AWS: MockAWS },
-					results: {}
 				};
-				findLambdaAliasStep(conan, context, stepDone(done));
-			});
-
-			it("should return the alias arn", () => {
-				stepReturnData.should.eql({ aliases: {} });
-			});
-		});
-
-		describe("(Not Found is Returned)", () => {
-			let errorMessage;
-
-			beforeEach(() => {
-				errorMessage = "AWS returned status code 404";
-				awsResponseError = { statusCode: 404, message: errorMessage };
-			});
-
-			it("should skip the alias because it does not exist", done => {
-				findLambdaAliasStep(conan, context, (error) => {
-					should.not.exist(error);
-					done();
-				});
-			});
-		});
-
-		describe("(Unknown Error is Returned)", () => {
-			let errorMessage;
-
-			beforeEach(done => {
 				errorMessage = "AWS returned status code 401";
 				awsResponseError = { statusCode: 401, message: errorMessage };
-				findLambdaAliasStep(conan, context, stepDone(done));
+				mockLambda.createAlias = sinon.spy((params, callback) => {
+					callback(awsResponseError, null);
+				});
+				createLambdaAliasStep(conan, context, stepDone(done));
 			});
 
 			it("should return an error which stops the step runner", () => {

--- a/es6/lib/plugins/aws-lambda/spec/steps/findLambdaAliasStep.spec.js
+++ b/es6/lib/plugins/aws-lambda/spec/steps/findLambdaAliasStep.spec.js
@@ -1,0 +1,163 @@
+import Conan from "../../../../conan.js";
+import findLambdaAliasStep from "../../steps/findLambdaAliasStep.js";
+import sinon from "sinon";
+
+describe(".findLambdaAliasStep(conan, context, stepDone)", () => {
+	let conan,
+			context,
+			stepDone,
+
+			awsResponseError,
+			firstAliasArn,
+			secondAliasArn,
+
+			responseData,
+
+			stepReturnError,
+			stepReturnData,
+
+			parameters;
+
+	const mockLambda = {
+		getAlias: sinon.spy((params, callback) => {
+			callback(awsResponseError, responseData());
+		})
+	};
+
+	const MockAWS = {
+		Lambda: sinon.spy(() => {
+			return mockLambda;
+		})
+	};
+
+	beforeEach(() => {
+		conan = new Conan({
+			region: "us-east-1"
+		});
+
+		parameters = new class MockConanAwsLambda {
+			lambda() { return "TestFunction"; }
+			alias() { return [["development"], ["production", "1"]]; }
+		}();
+
+		context = {
+			parameters: parameters,
+			libraries: { AWS: MockAWS },
+			results: {}
+		};
+
+		// "Role Found" response by default
+		firstAliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:development";
+		secondAliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:production";
+		responseData = sinon.stub();
+
+		awsResponseError = null;
+
+	});
+
+	describe("(When calling AWS)", () => {
+		beforeEach(done => {
+			stepDone = (afterStepCallback) => {
+				return (error, data) => {
+					stepReturnError = error;
+					stepReturnData = data;
+					afterStepCallback();
+				};
+			};
+
+			findLambdaAliasStep(conan, context, stepDone(done));
+		});
+
+		it("should be a function", () => {
+			(typeof findLambdaAliasStep).should.equal("function");
+		});
+
+		it("should set the designated region on the lambda client", () => {
+			MockAWS.Lambda.calledWith({
+				region: conan.config.region
+			}).should.be.true;
+		});
+
+		it("should call AWS with the designated function name parameter", () => {
+			mockLambda.getAlias.calledWith({
+				"FunctionName": context.parameters.lambda(),
+				"Name": "development"
+			}).should.be.true;
+		});
+
+		describe("(Alias is Found and Updated for Every Alias)", () => {
+			beforeEach(done => {
+				responseData = sinon.stub();
+				responseData.onCall(0).returns({
+					AliasArn: firstAliasArn,
+					FunctionVersion: "2"
+				});
+
+				responseData.onCall(1).returns({
+					AliasArn: secondAliasArn,
+					FunctionVersion: "3"
+				});
+				findLambdaAliasStep(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", () => {
+				stepReturnData.should.eql({
+					aliases: { "development": firstAliasArn, "production": secondAliasArn }
+				});
+			});
+		});
+
+		describe("(Alias is Found but Updated just for Some Alias)", () => {
+			beforeEach(() => {
+				responseData.onCall(0).returns({
+					AliasArn: firstAliasArn,
+					FunctionVersion: "$LATEST"
+				});
+
+				responseData.onCall(1).returns({
+					AliasArn: secondAliasArn,
+					FunctionVersion: "2"
+				});
+			});
+
+			it("should return the alias arn", () => {
+				stepReturnData.should.eql({
+					aliases: { "production": secondAliasArn }
+				});
+			});
+		});
+
+		describe("(Alias is not Found)", () => {
+			beforeEach(() => {
+				responseData = sinon.stub();
+				responseData.onCall(0).returns({
+					AliasArn: firstAliasArn,
+					FunctionVersion: "$LATEST"
+				});
+
+				responseData.onCall(1).returns({
+					AliasArn: secondAliasArn,
+					FunctionVersion: "2"
+				});
+			});
+
+			it("should return the alias arn", () => {
+				stepReturnData.should.eql({ aliases: {} });
+			});
+		});
+
+		describe("(Unknown Error is Returned)", () => {
+			let errorMessage;
+
+			beforeEach(done => {
+				errorMessage = "AWS returned status code 401";
+				awsResponseError = { statusCode: 401, message: errorMessage };
+				findLambdaAliasStep(conan, context, stepDone(done));
+			});
+
+			it("should return an error which stops the step runner", () => {
+				stepReturnError.message.should.eql(errorMessage);
+			});
+		});
+	});
+});

--- a/es6/lib/plugins/aws-lambda/spec/steps/findLambdaByNameStep.spec.js
+++ b/es6/lib/plugins/aws-lambda/spec/steps/findLambdaByNameStep.spec.js
@@ -4,19 +4,17 @@ import sinon from "sinon";
 
 describe(".findLambdaByNameStep(conan, context, stepDone)", () => {
 	let conan,
-			context,
-			stepDone,
+		context,
+		stepDone,
 
-			should,
+		awsResponseError,
+		awsResponseData,
 
-			awsResponseError,
-			awsResponseData,
+		stepReturnError,
+		stepReturnData,
 
-			stepReturnError,
-			stepReturnData,
-
-			parameters,
-			mockLambdaSpy;
+		parameters,
+		mockLambdaSpy;
 
 	const mockLambda = {
 		getFunction: sinon.spy((params, callback) => {
@@ -91,7 +89,7 @@ describe(".findLambdaByNameStep(conan, context, stepDone)", () => {
 	describe("(No Lambda parameter)", () => {
 		it("should skip the call entirely", done => {
 			parameters = new class MockConanAwsLambda {
-				lambda() { return null; }
+				lambda() { return []; }
 			}();
 
 			context = {
@@ -120,7 +118,7 @@ describe(".findLambdaByNameStep(conan, context, stepDone)", () => {
 
 		it("should work indistinctly with a lambda parameters instead of a name parameter", done => {
 			parameters = new class MockConanAwsLambda {
-				lambda() { return "TestFunctionWithLambda"; }
+				lambda() { return ["TestFunctionWithLambda"]; }
 			}();
 
 			context = {

--- a/es6/lib/plugins/aws-lambda/spec/steps/publishLambdaVersionStep.spec.js
+++ b/es6/lib/plugins/aws-lambda/spec/steps/publishLambdaVersionStep.spec.js
@@ -1,0 +1,105 @@
+import Conan from "../../../../conan.js";
+import publishLambdaVersionStep from "../../steps/publishLambdaVersionStep.js";
+import sinon from "sinon";
+
+describe(".publishLambdaVersionStep(conan, context, stepDone)", () => {
+	let conan,
+			context,
+			stepDone,
+
+			awsResponseError,
+			awsResponseData,
+
+			stepReturnError,
+			stepReturnData,
+
+			parameters;
+
+	const mockLambda = {
+		publishVersion: sinon.spy((params, callback) => {
+			callback(awsResponseError, awsResponseData);
+		})
+	};
+
+	const MockAWS = {
+		Lambda: sinon.spy(() => {
+			return mockLambda;
+		})
+	};
+
+	beforeEach(() => {
+		conan = new Conan({
+			region: "us-east-1"
+		});
+
+		parameters = new class MockConanAwsLambda {
+			lambda() { return "TestFunction"; }
+		}();
+
+		context = {
+			parameters: parameters,
+			libraries: { AWS: MockAWS },
+			results: {}
+		};
+
+		// "Role Found" response by default
+		awsResponseData = {
+			Version: "1"
+		};
+		awsResponseError = null;
+
+	});
+
+	describe("(When calling AWS)", () => {
+		beforeEach(done => {
+			stepDone = (afterStepCallback) => {
+				return (error, data) => {
+					stepReturnError = error;
+					stepReturnData = data;
+					afterStepCallback();
+				};
+			};
+
+			publishLambdaVersionStep(conan, context, stepDone(done));
+		});
+
+		it("should be a function", () => {
+			(typeof publishLambdaVersionStep).should.equal("function");
+		});
+
+		it("should set the designated region on the lambda client", () => {
+			MockAWS.Lambda.calledWith({
+				region: conan.config.region
+			}).should.be.true;
+		});
+
+		it("should call AWS with the designated function name parameter", () => {
+			mockLambda.publishVersion.calledWith({
+				"FunctionName": context.parameters.lambda(),
+				"Description": "conan autopublish step"
+			}).should.be.true;
+		});
+
+		describe("(Version is Published)", () => {
+			it("should return the version number", () => {
+				stepReturnData.should.eql({
+					lambdaVersion: awsResponseData.Version
+				});
+			});
+		});
+
+		describe("(Unknown Error is Returned)", () => {
+			let errorMessage;
+
+			beforeEach(done => {
+				errorMessage = "AWS returned status code 401";
+				awsResponseError = { statusCode: 401, message: errorMessage };
+				publishLambdaVersionStep(conan, context, stepDone(done));
+			});
+
+			it("should return an error which stops the step runner", () => {
+				stepReturnError.message.should.eql(errorMessage);
+			});
+		});
+	});
+});

--- a/es6/lib/plugins/aws-lambda/spec/steps/publishLambdaVersionStep.spec.js
+++ b/es6/lib/plugins/aws-lambda/spec/steps/publishLambdaVersionStep.spec.js
@@ -33,7 +33,7 @@ describe(".publishLambdaVersionStep(conan, context, stepDone)", () => {
 		});
 
 		parameters = new class MockConanAwsLambda {
-			lambda() { return "TestFunction"; }
+			name() { return "TestFunction"; }
 		}();
 
 		context = {
@@ -75,7 +75,7 @@ describe(".publishLambdaVersionStep(conan, context, stepDone)", () => {
 
 		it("should call AWS with the designated function name parameter", () => {
 			mockLambda.publishVersion.calledWith({
-				"FunctionName": context.parameters.lambda(),
+				"FunctionName": context.parameters.name(),
 				"Description": "conan autopublish step"
 			}).should.be.true;
 		});

--- a/es6/lib/plugins/aws-lambda/spec/steps/updateLambdaAliasStep.spec.js
+++ b/es6/lib/plugins/aws-lambda/spec/steps/updateLambdaAliasStep.spec.js
@@ -1,0 +1,241 @@
+import Conan from "../../../../conan.js";
+import updateLambdaAliasStep from "../../steps/updateLambdaAliasStep.js";
+import sinon from "sinon";
+
+describe(".updateLambdaAliasStep(conan, context, stepDone)", () => {
+	let conan,
+			context,
+			stepDone,
+
+			awsResponseError,
+			aliasArn,
+			functionVersion,
+
+			responseData,
+
+			stepReturnError,
+			stepReturnData,
+
+			parameters;
+
+	let mockLambda = {
+		updateAlias: sinon.spy((params, callback) => {
+			callback(awsResponseError, responseData(params));
+		})
+	};
+
+	let MockAWS = {
+		Lambda: sinon.spy(() => {
+			return mockLambda;
+		})
+	};
+
+	beforeEach(() => {
+		conan = new Conan({
+			region: "us-east-1"
+		});
+
+		parameters = new class MockConanAwsLambda {
+			name() { return "TestFunction"; }
+			alias() { return [["development"], ["production", "1"]]; }
+		}();
+
+		aliasArn = "arn:aws:lambda:aws-regions:accct-id:function:example:alias";
+		functionVersion = "version";
+
+		context = {
+			parameters: parameters,
+			libraries: { AWS: MockAWS },
+			results: {
+				aliases: {
+					"development": {},
+					"production": {}
+				}
+			}
+		};
+
+		awsResponseError = null;
+
+		responseData = sinon.stub();
+		responseData.returns({AliasArn: aliasArn, FunctionVersion: functionVersion});
+	});
+
+	describe("(When calling AWS)", () => {
+		beforeEach(done => {
+			stepDone = (afterStepCallback) => {
+				return (error, data) => {
+					stepReturnError = error;
+					stepReturnData = data;
+					afterStepCallback();
+				};
+			};
+
+			updateLambdaAliasStep(conan, context, stepDone(done));
+		});
+
+		it("should be a function", () => {
+			(typeof updateLambdaAliasStep).should.equal("function");
+		});
+
+		it("should set the designated region on the lambda client", () => {
+			MockAWS.Lambda.calledWith({
+				region: conan.config.region
+			}).should.be.true;
+		});
+
+		it("should call AWS with the designated function name parameter", () => {
+			mockLambda.updateAlias.calledWith({
+				"FunctionName": context.parameters.name(),
+				"FunctionVersion": "$LATEST",
+				"Description": "conan auto updated alias",
+				"Name": "development"
+			}).should.be.true;
+		});
+
+		describe("(Alias Update Request for Every Alias)", () => {
+			beforeEach(done => {
+				parameters = new class MockConanAwsLambda {
+					name() { return "TestFunction"; }
+					alias() { return [["development-all"], ["production-all", "1"]]; }
+				}();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-all": {
+								aliasArn
+							},
+							"production-all": {
+								aliasArn
+							}
+						}
+					}
+				};
+				updateLambdaAliasStep(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", () => {
+				stepReturnData.should.eql({
+					aliases: {
+						"development-all": {
+							aliasArn,
+							functionVersion
+						},
+						"production-all": {
+							aliasArn,
+							functionVersion
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias Update Request for Some Alias)", () => {
+			beforeEach(done => {
+				parameters = new class MockConanAwsLambda {
+					name() { return "TestFunction"; }
+					alias() { return [["development-some"], ["production-some", "2"], ["staging-some", "1"]]; }
+				}();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-some": {
+								aliasArn,
+								functionVersion: "version"
+							},
+							"staging-some": {
+								aliasArn
+							},
+							"production-some": {
+								aliasArn
+							}
+						}
+					}
+				};
+				updateLambdaAliasStep(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", () => {
+				stepReturnData.should.eql({
+					aliases: {
+						"production-some": {
+							aliasArn,
+							functionVersion
+						},
+						"staging-some": {
+							aliasArn,
+							functionVersion
+						},
+						"development-some": {
+							aliasArn,
+							functionVersion
+						}
+					}
+				});
+			});
+		});
+
+		describe("(Alias No Update Request made)", () => {
+			let aliases;
+			beforeEach(done => {
+				parameters = new class MockConanAwsLambda {
+					alias() { return [["development"], ["production", "1"]]; }
+				}();
+				aliases = {
+					"development": { aliasArn, functionVersion },
+					"production": { aliasArn, functionVersion }
+				};
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases
+					}
+				};
+				updateLambdaAliasStep(conan, context, stepDone(done));
+			});
+
+			it("should return the alias arn", () => {
+				stepReturnData.should.eql({ aliases });
+			});
+		});
+
+		describe("(Unknown Error is Returned)", () => {
+			let errorMessage;
+
+			beforeEach(done => {
+				parameters = new class MockConanAwsLambda {
+					name() { return "TestFunction"; }
+					alias() { return [["development-some"], ["production-some", "1"]]; }
+				}();
+
+				context = {
+					parameters: parameters,
+					libraries: { AWS: MockAWS },
+					results: {
+						aliases: {
+							"development-some": { aliasArn },
+							"production-some": { aliasArn, functionVersion }
+						}
+					}
+				};
+				errorMessage = "AWS returned status code 401";
+				awsResponseError = { statusCode: 401, message: errorMessage };
+				mockLambda.updateAlias = sinon.spy((params, callback) => {
+					callback(awsResponseError, null);
+				});
+				updateLambdaAliasStep(conan, context, stepDone(done));
+			});
+
+			it("should return an error which stops the step runner", () => {
+				stepReturnError.message.should.eql(errorMessage);
+			});
+		});
+	});
+});

--- a/es6/lib/plugins/aws-lambda/steps/createLambdaAliasStep.js
+++ b/es6/lib/plugins/aws-lambda/steps/createLambdaAliasStep.js
@@ -1,0 +1,50 @@
+import flowsync from "flowsync";
+
+export default function createLambdaAliasStep(conan, context, stepDone) {
+	const AWS = context.libraries.AWS;
+	const iam = new AWS.Lambda({
+		region: conan.config.region
+	});
+
+	const aliases = context.parameters.alias();
+	const result = { };
+	flowsync.eachSeries(aliases,
+		(alias, next) => {
+			const aliasName = alias[0];
+			let aliasVersion;
+			if(alias.length > 1) {
+				aliasVersion = alias[1];
+			} else {
+				aliasVersion = "$LATEST";
+			}
+
+			let aliasExists;
+			if(context.results.aliases) {
+				aliasExists = context.results.aliases[aliasName];
+			}
+
+			if(!aliasExists) {
+				iam.createAlias({
+					"FunctionName": context.parameters.name(),
+					"FunctionVersion": aliasVersion,
+					"Name": aliasName,
+					"Description": "conan auto created alias"
+				}, (error, responseData) => {
+					if(responseData) {
+						result[aliasName] = {
+							aliasArn: responseData.AliasArn,
+							functionVersion: responseData.FunctionVersion
+						};
+						next();
+					} else {
+						next(error);
+					}
+				});
+			} else {
+				next();
+			}
+		},
+		(error) => {
+			stepDone(error, { aliases: result });
+		});
+}

--- a/es6/lib/plugins/aws-lambda/steps/findLambdaAliasStep.js
+++ b/es6/lib/plugins/aws-lambda/steps/findLambdaAliasStep.js
@@ -1,0 +1,37 @@
+import flowsync from "flowsync";
+
+export default function findLambdaAliasStep(conan, context, stepDone) {
+	const AWS = context.libraries.AWS;
+	const iam = new AWS.Lambda({
+		region: conan.config.region
+	});
+
+	const aliases = context.parameters.alias();
+	const result = { };
+	flowsync.eachSeries(aliases,
+		(alias, next) => {
+			const aliasName = alias[0];
+			let aliasVersion;
+			if(alias.length > 1) {
+				aliasVersion = alias[1];
+			} else {
+				aliasVersion = "$LATEST";
+			}
+			console.log("calling get aalias for " + aliasName);
+			iam.getAlias({
+				"FunctionName": context.parameters.lambda(),
+				"Name": aliasName
+			}, (error, responseData) => {
+				console.log("get alias returns ", {error, responseData});
+				if(responseData && responseData.FunctionVersion === aliasVersion) {
+					result[aliasName] = responseData.AliasArn;
+					next();
+				} else {
+					next(error);
+				}
+			});
+		},
+		(error) => {
+			stepDone(error, { aliases: result });
+		});
+}

--- a/es6/lib/plugins/aws-lambda/steps/findLambdaByNameStep.js
+++ b/es6/lib/plugins/aws-lambda/steps/findLambdaByNameStep.js
@@ -7,7 +7,7 @@ export default function findLambdaByNameStep(conan, context, stepDone) {
 	if(typeof context.parameters.name === "function") {
 		lambdaName = context.parameters.name();
 	} else {
-		lambdaName = context.parameters.lambda();
+		lambdaName = context.parameters.lambda()[0];
 	}
 
 	if(lambdaName) {

--- a/es6/lib/plugins/aws-lambda/steps/publishLambdaVersionStep.js
+++ b/es6/lib/plugins/aws-lambda/steps/publishLambdaVersionStep.js
@@ -5,7 +5,7 @@ export default function publishLambdaVersionStep(conan, context, stepDone) {
 	});
 
 	iam.publishVersion({
-		"FunctionName": context.parameters.lambda(),
+		"FunctionName": context.parameters.name(),
 		"Description": "conan autopublish step"
 	}, (error, responseData) => {
 		if (error) {

--- a/es6/lib/plugins/aws-lambda/steps/publishLambdaVersionStep.js
+++ b/es6/lib/plugins/aws-lambda/steps/publishLambdaVersionStep.js
@@ -1,0 +1,19 @@
+export default function publishLambdaVersionStep(conan, context, stepDone) {
+	const AWS = context.libraries.AWS;
+	const iam = new AWS.Lambda({
+		region: conan.config.region
+	});
+
+	iam.publishVersion({
+		"FunctionName": context.parameters.lambda(),
+		"Description": "conan autopublish step"
+	}, (error, responseData) => {
+		if (error) {
+			stepDone(error);
+		} else {
+			stepDone(null, {
+				lambdaVersion: responseData.Version
+			});
+		}
+	});
+}

--- a/es6/lib/plugins/aws-lambda/steps/updateLambdaAliasStep.js
+++ b/es6/lib/plugins/aws-lambda/steps/updateLambdaAliasStep.js
@@ -1,0 +1,46 @@
+import flowsync from "flowsync";
+
+export default function updateLambdaAliasStep(conan, context, stepDone) {
+	const AWS = context.libraries.AWS;
+	const iam = new AWS.Lambda({
+		region: conan.config.region
+	});
+
+	const aliases = context.parameters.alias();
+	const result = context.results.aliases;
+	flowsync.eachSeries(aliases,
+		(alias, next) => {
+			const aliasName = alias[0];
+			let aliasVersion;
+			if(alias.length > 1) {
+				aliasVersion = alias[1];
+			} else {
+				aliasVersion = "$LATEST";
+			}
+
+			if(context.results.aliases
+				&& !context.results.aliases[aliasName].functionVersion) {
+				iam.updateAlias({
+					"FunctionName": context.parameters.name(),
+					"FunctionVersion": aliasVersion,
+					"Name": aliasName,
+					"Description": "conan auto updated alias"
+				}, (error, responseData) => {
+					if(responseData) {
+						result[aliasName] = {
+							aliasArn: responseData.AliasArn,
+							functionVersion: responseData.FunctionVersion
+						};
+						next();
+					} else {
+						next(error);
+					}
+				});
+			} else {
+				next();
+			}
+		},
+		(error) => {
+			stepDone(error, { aliases: result });
+		});
+}

--- a/es6/lib/plugins/aws-lambda/steps/updateLambdaAliasStep.js
+++ b/es6/lib/plugins/aws-lambda/steps/updateLambdaAliasStep.js
@@ -19,6 +19,7 @@ export default function updateLambdaAliasStep(conan, context, stepDone) {
 			}
 
 			if(context.results.aliases
+				&& context.results.aliases[aliasName]
 				&& !context.results.aliases[aliasName].functionVersion) {
 				iam.updateAlias({
 					"FunctionName": context.parameters.name(),


### PR DESCRIPTION
Support alias as the second argument when creating api gateway resources.
Example
conan
.api("nicoFam")
  .stage("development")
    .get("/accounts")
      .headers("Access-Token", "Content-Type")
      .lambda("accountList", "development")
